### PR TITLE
Add simple Flask UI to upload PDFs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,27 @@
-bleep bloop
+# Claim Parser
+
+This project parses healthcare claim PDFs (HCFA-1500 claim forms and Explanation of Benefits documents). It now includes a small web interface for uploading PDFs via drag and drop.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Command-line usage
+
+```bash
+python pdf_claim_parser.py "path/to/*.pdf" --output results.json
+```
+
+## Web UI
+
+Run the web application:
+
+```bash
+python web_app.py
+```
+
+Then open [http://localhost:5000](http://localhost:5000) in your browser. Drag and drop one or more PDF files onto the page and the parsed JSON will appear below the drop area.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+pdfplumber
+python-dateutil
+pypdf
+rich

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Claim PDF Parser</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em; }
+        #dropzone { border: 2px dashed #ccc; padding: 2em; text-align: center; color: #777; }
+        #dropzone.dragover { border-color: #333; color: #333; }
+        pre { background: #f4f4f4; padding: 1em; white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <h1>Upload Claim PDFs</h1>
+    <div id="dropzone">Drag & Drop PDFs here or click to select</div>
+    <input type="file" id="fileInput" multiple accept="application/pdf" style="display:none" />
+    <pre id="output"></pre>
+    <script>
+    const dropzone = document.getElementById('dropzone');
+    const fileInput = document.getElementById('fileInput');
+    dropzone.addEventListener('click', () => fileInput.click());
+    dropzone.addEventListener('dragover', e => { e.preventDefault(); dropzone.classList.add('dragover'); });
+    dropzone.addEventListener('dragleave', () => dropzone.classList.remove('dragover'));
+    dropzone.addEventListener('drop', e => { e.preventDefault(); dropzone.classList.remove('dragover'); handleFiles(e.dataTransfer.files); });
+    fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+    function handleFiles(files) {
+        const formData = new FormData();
+        for (const f of files) formData.append('files', f);
+        fetch('/upload', { method: 'POST', body: formData })
+            .then(r => r.json())
+            .then(data => { document.getElementById('output').textContent = JSON.stringify(data, null, 2); })
+            .catch(err => alert('Error: ' + err));
+    }
+    </script>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from flask import Flask, render_template, request, jsonify
+from pathlib import Path
+import tempfile
+
+from pdf_claim_parser import parse_file
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    files = request.files.getlist('files')
+    results = []
+    for f in files:
+        if not f:
+            continue
+        with tempfile.NamedTemporaryFile(delete=True, suffix='.pdf') as tmp:
+            f.save(tmp.name)
+            results.append(parse_file(Path(tmp.name)))
+    return jsonify(results)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- create `web_app.py` with Flask routes to upload PDFs and parse them
- add drag-and-drop HTML UI for uploads
- document new web interface and setup in README
- add requirements file with needed packages

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68823353c56c832db0aedd4718ca60dd