### PR TITLE
Fix tests import path

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,13 @@
 import builtins
 from decimal import Decimal
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path so ``pdf_claim_parser`` can
+# be imported when tests are executed from within the ``tests`` directory.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 import pdf_claim_parser as parser
 


### PR DESCRIPTION
## Summary
- fix tests to adjust Python path for imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68823afb9f8c832d94f553c00e9a9c3e