### PR TITLE
Improve claim parser output formatting

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -10,22 +10,29 @@ import streamlit as st
 from pdf_claim_parser import parse_file
 
 
+st.set_page_config(page_title="Claim PDF Parser", layout="wide")
 st.title("Claim PDF Parser")
+st.sidebar.header("Instructions")
+st.sidebar.write("Upload one or more claim PDFs to parse them.")
 
 uploaded_files = st.file_uploader(
     "Upload claim PDFs", type="pdf", accept_multiple_files=True
 )
 
 if uploaded_files:
-    results = []
     for uploaded in uploaded_files:
         if not uploaded:
             continue
         with tempfile.NamedTemporaryFile(delete=True, suffix=".pdf") as tmp:
             tmp.write(uploaded.read())
             tmp.flush()
-            results.append(parse_file(Path(tmp.name)))
-    st.json(results)
+            result = parse_file(Path(tmp.name))
+        with st.expander(uploaded.name):
+            meta = {k: v for k, v in result.items() if k != "service_lines"}
+            st.json(meta)
+            lines = result.get("service_lines") or []
+            if lines:
+                st.table(lines)
 
 if __name__ == "__main__":
     st.write("Run this app with: streamlit run web_app.py")


### PR DESCRIPTION
## Summary
- enhance money parsing to handle negative values
- expand classification keyword lists
- add pretty printing using `rich` in CLI
- display parsed data in expandable sections in Streamlit UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6882438b6270832d9b470cb0931e0dd8