### PR TITLE
Improve document classification

### DIFF
--- a/pdf_claim_parser.py
+++ b/pdf_claim_parser.py
@@ -67,28 +67,32 @@ class ServiceLine:
 # ---------------------------------------------------------------------------
 # Classification
 # ---------------------------------------------------------------------------
-HCFA_KEYWORDS = [
-    "CMS-1500",
-    "HCFA",
-    "24J",
-    "CLAIM FORM",
+HCFA_PATTERNS = [
+    r"CMS[-\s]?1500",
+    r"HCFA[-\s]?1500",
+    r"HCFA",
+    r"HEALTH\s+INSURANCE\s+CLAIM\s+FORM",
+    r"\b24J\b",
 ]
 
-EOB_KEYWORDS = [
-    "EXPLANATION OF BENEFITS",
-    "EOB",
-    "CLAIM SUMMARY",
-    "PATIENT RESPONSIBILITY",
+EOB_PATTERNS = [
+    r"EXPLANATION\s+OF\s+BENEFITS",
+    r"REMITTANCE\s+ADVICE",
+    r"EXPLANATION\s+OF\s+PAYMENT",
+    r"\bEOB\b",
+    r"CLAIM\s+SUMMARY",
+    r"PATIENT\s+RESPONSIBILITY",
 ]
 
 
 def classify_text(text: str) -> Optional[str]:
     """Return ``HCFA`` or ``EOB`` based on keyword presence."""
-    upper = text.upper()
-    if any(k in upper for k in HCFA_KEYWORDS):
-        return "HCFA"
-    if any(k in upper for k in EOB_KEYWORDS):
-        return "EOB"
+    for pattern in HCFA_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            return "HCFA"
+    for pattern in EOB_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            return "EOB"
     return None
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,17 @@ def test_classify_text_hcfa():
 
 
 def test_classify_text_eob():
-    text = "EXPLANATION OF BENEFITS statement" 
+    text = "EXPLANATION OF BENEFITS statement"
+    assert parser.classify_text(text) == "EOB"
+
+
+def test_classify_text_cms_variant():
+    text = "This document uses the CMS 1500 health insurance claim form"
+    assert parser.classify_text(text) == "HCFA"
+
+
+def test_classify_text_remittance_advice():
+    text = "Please see the remittance advice for payment details"
     assert parser.classify_text(text) == "EOB"
 
 


### PR DESCRIPTION
## Summary
- broaden detection patterns for HCFA and EOB
- adjust `classify_text` to use regex
- add tests for additional classification scenarios

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688259939744832d9250e5aaee130f70