### PR TITLE
Fix Tailwind base styling error

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  @apply bg-gray-50 text-gray-900;
+@layer base {
+  body {
+    @apply bg-gray-50 text-gray-900;
+  }
 }


### PR DESCRIPTION
## Summary
- wrap body `@apply` usage in a base layer so Tailwind recognizes the utility classes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68827a74d244832db04dc621c435c1d3