### PR TITLE
Fix Tailwind color utilities

### DIFF
--- a/web/src/components/UploadArea.tsx
+++ b/web/src/components/UploadArea.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
-import { parseFile, ParseResult } from '../parser'
+import { parseFile } from '../parser'
+import type { ParseResult } from '../parser'
 
 export default function UploadArea() {
   const inputRef = useRef<HTMLInputElement>(null)

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -1,9 +1,14 @@
+const colors = require('tailwindcss/colors')
+
 module.exports = {
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
+    colors: {
+      ...colors,
+    },
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- include default color palette when using Tailwind v4
- update `UploadArea.tsx` to use type-only import

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68828b0a69bc832db15de25f665bde6b